### PR TITLE
Ensure volume is set up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       - "3000:3000"
       - "9230:9230"
       - "9229:9229"
-    # volumes:
-    #   - ./nextjs/.next/:/app/nextjs/.next/:z
+    volumes:
+      - ./nextjs/.next/:/app/nextjs/.next/:z
     command: npm run dev
     restart: always
     environment:


### PR DESCRIPTION
Worked with @sokra to investigate further. The reason the breakpoints didn't work is that the volume for `.next` wasn't mounted. VS Code and the Chrome debugger need to be able to read the sourcemaps from disk and weren't able to do that because the files weren't mounted in the host machine. This solves that problem.

As far as we could find in the VS Code documentation it is expected that the source/compiled output get mounted into the host as otherwise the debugger can't find relevant files like the sourcemaps. The reason this worked with webpack is that webpack inlines all sourcemaps, however we want to mirror production builds more with Turbopack, so it's written as a separate file. 